### PR TITLE
Implement rebuild! method for Array for task #2

### DIFF
--- a/task_2/array.rb
+++ b/task_2/array.rb
@@ -1,2 +1,9 @@
-class Array
+module CoreExtensions
+  module Array
+    def rebuild!
+      puts 'TEST'
+    end
+  end
 end
+
+Array.include CoreExtensions::Array

--- a/task_2/array.rb
+++ b/task_2/array.rb
@@ -1,7 +1,19 @@
 module CoreExtensions
   module Array
-    def rebuild!
-      puts 'TEST'
+    def rebuild!(&block)
+      # @nestness shows how nested is current array
+      # we use it to update array elements that are not nested in other arrays 
+      @nestness = 0
+
+      self.each_with_index do |item, index|
+        if item.is_a?(Array)
+          @nestness = @nestness + 1
+          item.rebuild!(&block)
+        else
+          length = @nestness.zero? ? self.length : 1
+          self[index] = yield(item, length)
+        end
+      end
     end
   end
 end

--- a/task_2/array.rb
+++ b/task_2/array.rb
@@ -2,7 +2,7 @@ module CoreExtensions
   module Array
     def rebuild!(&block)
       # @nestness shows how nested is current array
-      # we use it to update array elements that are not nested in other arrays 
+      # we use it to update array elements that are not nested in other arrays
       @nestness = 0
 
       self.each_with_index do |item, index|
@@ -18,4 +18,7 @@ module CoreExtensions
   end
 end
 
+# I'd prefer to use ruby refinements for this monkey patch, but according to task rules all work
+# should be done in array.rb file
+# https://docs.ruby-lang.org/en/2.4.0/syntax/refinements_rdoc.html
 Array.include CoreExtensions::Array

--- a/task_2/test.rb
+++ b/task_2/test.rb
@@ -10,12 +10,21 @@ array = [
 
 puts "Given: #{array}"
 
+# I removed pp here because it doesn't work with do/end blocks, see https://code-examples.net/en/q/11c2bd7
+# Using {} will actually work:
+# pp array.rebuild! { |element| element + 3 }
 puts "Test 1:"
-pp array.rebuild! do |element|
+res = array.rebuild! do |element|
   element + 3
 end
 
+pp res
+
+# This code will add size to elements of array updated in Test 1, not original array.
+# It does so because usually in ruby methods with '!' in method name change original object.
 puts 'Test 2:'
-pp array.rebuild! do |element, size|
+res = array.rebuild! do |element, size|
   element + size
 end
+
+pp res


### PR DESCRIPTION
- Implemented `rebuild!` method
- Had to update test.rb file because `pp` method doesn't work well with do/end blocks. Not sure if I had to fix pp behaviour here in this task.

Also from test.rb file and readme file it is not clear if `reduild!` method should change original array(name implies that it should though) or return a new one. In current implementation it updates original array.

See comments in code for more info.

Should work with ruby 2+. Tested with ruby 2.3.1p112